### PR TITLE
Fix Caddy's streaming API matching

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -11,4 +11,4 @@
 # }
 
 reverse_proxy :3000
-reverse_proxy /api/v1/streaming :4000
+reverse_proxy /api/v1/streaming/* :4000


### PR DESCRIPTION
Hey! So first, thanks to this repo, I saved a lot of time and got up and running quickly. Thank you very much! :heart: 

After setup, I noticed that the streaming API was not accessible. If you check out the console, it'll look like this:

![image](https://user-images.githubusercontent.com/6065401/210258781-97b374ee-5900-4e63-bf86-3a84d09a970a.png)

The reason for this is pattern matching in Caddy v2 is now exact and the web client, by default, requests. `/api/v1/streaming/?` (and potentially uses additional parameters). This PR changes the matching and properly reverse proxies the streaming API again. :)

**Details**

* The web client requests  `/api/v1/streaming/?` as a default websocket URL, but [it can add parameters and channel names as URL parameters, too](https://github.com/mastodon/mastodon/blob/c3aef491d66aec743a3a53e934a494f653745b61/app/javascript/mastodon/stream.js#L127-L149).
* Because of [the change from Caddy v1 -> Caddy v2](https://caddyserver.com/docs/v2-upgrade#primary-changes:~:text=Where%20you%20matched%20requests%20by%20path%20prefix%20in%20Caddy%201%2C%20path%20matching%20is%20now%20exact%20by%20default%20in%20Caddy%202.%20If%20you%20want%20to%20match%20a%20prefix%20like%20/foo/%2C%20you%27ll%20need%20/foo/*%20in%20Caddy%202.), Caddy's matching is now exact. We matched `/api/v1/streaming`, but because the client only ever requested `api/v1/streaming/?`, it never matched. To fix this and accommodate additional parameters, we want to match everything after it, too, thus I added a wildcard.

