### PR TITLE
Fly v2 with Mastodon v4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Releases: https://github.com/mastodon/mastodon/releases
-FROM tootsuite/mastodon:v4.2.0
+# Releases: https://github.com/mastodon/mastodon/pkgs/container/mastodon
+FROM ghcr.io/mastodon/mastodon:v4.2.3
 
 USER root
 
@@ -9,7 +9,7 @@ RUN mkdir -p /var/cache/apt/archives/partial && \
   apt-get install -y --no-install-recommends tmux
 
 # Releases: https://github.com/caddyserver/caddy/releases/
-RUN wget "https://github.com/caddyserver/caddy/releases/download/v2.7.4/caddy_2.7.4_linux_amd64.deb" -O caddy.deb && \
+RUN wget "https://github.com/caddyserver/caddy/releases/download/v2.7.6/caddy_2.7.6_linux_amd64.deb" -O caddy.deb && \
   dpkg -i caddy.deb
 
 USER mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Releases: https://github.com/mastodon/mastodon/releases
-FROM tootsuite/mastodon:v4.1.6
+FROM tootsuite/mastodon:v4.2.0
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /var/cache/apt/archives/partial && \
   apt-get install -y --no-install-recommends tmux
 
 # Releases: https://github.com/caddyserver/caddy/releases/
-RUN wget "https://github.com/caddyserver/caddy/releases/download/v2.6.4/caddy_2.6.4_linux_amd64.deb" -O caddy.deb && \
+RUN wget "https://github.com/caddyserver/caddy/releases/download/v2.7.4/caddy_2.7.4_linux_amd64.deb" -O caddy.deb && \
   dpkg -i caddy.deb
 
 USER mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
+# Releases: https://github.com/mastodon/mastodon/releases
 FROM tootsuite/mastodon:v4.1.6
 
 USER root
+
 RUN mkdir -p /var/cache/apt/archives/partial && \
   apt-get clean && \
   apt-get update && \
   apt-get install -y --no-install-recommends tmux
 
+# Releases: https://github.com/caddyserver/caddy/releases/
 RUN wget "https://github.com/caddyserver/caddy/releases/download/v2.6.4/caddy_2.6.4_linux_amd64.deb" -O caddy.deb && \
   dpkg -i caddy.deb
 
 USER mastodon
+
+# Releases: https://github.com/DarthSim/overmind/releases
 RUN wget "https://github.com/DarthSim/overmind/releases/download/v2.4.0/overmind-v2.4.0-linux-amd64.gz" -O overmind.gz && \
   gunzip overmind.gz && \
   chmod +x overmind

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ After that, just deploy the updated container as usual, and the post-deploy migr
 fly deploy
 ```
 
+You should also regularly update the Postgres and Redis instances:
+
+- `flyctl image update -a mastodon-mountainash-db` to update Postgres
+- `./bin/fly-redis deploy` to update Redis
+
 ### Scaling your instance
 
 If your instance attracts many users (or maybe a few users who follow a huge number of other accounts), you may notice things start to slow down, and you may run out of database, redis, or storage space.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ fly deploy
 
 You should also regularly update the Postgres and Redis instances:
 
-- `flyctl image update -a mastodon-mountainash-db` to update Postgres
+- `flyctl image update -a mastodon-example-db` to update Postgres
 - `./bin/fly-redis deploy` to update Redis
 
 ### Scaling your instance

--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,8 @@
 app = "mastodon-example"
+primary_region = "sjc"
 
 kill_signal = "SIGINT"
-kill_timeout = 5
+kill_timeout = "5s"
 
 ## Uncomment if you are upgrading Mastodon. See README.md for details.
 # [deploy]
@@ -35,6 +36,7 @@ kill_timeout = 5
 [mounts]
   source = "mastodon_uploads"
   destination = "/opt/mastodon/public/system"
+  processes = ["app"]
 
 ## If you uncomment this to scale up to more VMs,
 ##   - Remove the entire [mounts] section above
@@ -68,15 +70,20 @@ kill_timeout = 5
     handlers = ["tls", "http"]
     port = 443
 
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+
   [[services.tcp_checks]]
     grace_period = "1s"
     interval = "15s"
-    restart_limit = 0
     timeout = "2s"
 
   [[services.http_checks]]
+    method = "get"
+    protocol = "http"
     path = "/health"
     grace_period = "1s"
     interval = "15s"
-    restart_limit = 0
     timeout = "2s"

--- a/fly.toml
+++ b/fly.toml
@@ -65,6 +65,7 @@ kill_timeout = "5s"
   [[services.ports]]
     handlers = ["http"]
     port = 80
+    force_https = true
 
   [[services.ports]]
     handlers = ["tls", "http"]
@@ -79,6 +80,7 @@ kill_timeout = "5s"
     grace_period = "1s"
     interval = "15s"
     timeout = "2s"
+    tls_skip_verify = false
 
   [[services.http_checks]]
     method = "get"

--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,7 @@ kill_timeout = "5s"
   RAILS_SERVE_STATIC_FILES = "false"
   REDIS_HOST = "mastodon-example-redis.internal"
   REDIS_PORT = "6379"
+  REDIS_URL = "redis://mastodon-example-redis.internal:6379/?family=6"
   ## Storage on S3 also requires secrets named AWS_ACCESS_KEY_ID and 
   ## AWS_SECRET_ACCESS_KEY. If you use this, remove [mounts] below.
   # S3_ENABLED=true


### PR DESCRIPTION
**NOTE: this change needs a database migration**

- Mastodon v4.2
- Update `fly.toml` to Fly.io v2 standard
- Forcing HTTPS
- Other dependency updates.