### PR TITLE
Remove tmux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ FROM ghcr.io/mastodon/mastodon:v4.2.7
 
 USER root
 
-RUN mkdir -p /var/cache/apt/archives/partial && \
-  apt-get clean && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends tmux
-
 # Releases: https://github.com/caddyserver/caddy/releases/
 RUN wget "https://github.com/caddyserver/caddy/releases/download/v2.7.6/caddy_2.7.6_linux_amd64.deb" -O caddy.deb && \
   dpkg -i caddy.deb


### PR DESCRIPTION
@tmm1 I don't really see a need for this to be installed? It was probably handy during project setup, but is it still needed in all installs?