### PR TITLE
Readme: app name clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You'll need a [Fly.io](https://fly.io/) account, and the [Flyctl CLI](https://fl
 
 ### App
 
-Fork this repo and clone a copy of it. Choose a name for your app that isn't already taken on https://fly.io/, and run the script `bin/name YOURNAME`. Follow this readme from inside your repo, after you have run the script, so that all of the steps will be updated for the name of your Fly.io app.
+Fork this repo and clone a copy of it. Choose a name for your app that isn't already taken on https://fly.io/, and run the script `bin/name YOUR-APP-NAME`. Follow this readme from inside your repo, after you have run the script, so that all of the steps will be updated for the name of your Fly.io app.
 
 ```bash
 fly apps create mastodon-example


### PR DESCRIPTION
This clarifies that `/bin/name` is looking for your app’s name, not “your name” (e.g. a username, or something similar)

Thanks for creating and maintaining this repo!